### PR TITLE
Update FHIR dependency for v1 plan evaluator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,13 +6,13 @@
 
 	<artifactId>opensrp-plan-evaluator</artifactId>
 	<packaging>jar</packaging>
-	<version>0.0.19-SNAPSHOT</version>
+	<version>0.0.19-CHWv1-SNAPSHOT</version>
 	<name>OpenSRP  Plan Evaluator</name>
 	<description>OpenSRP  Plan Evaluator Library</description>
 	<url>https://github.com/OpenSRP/opensrp-plan-evaluator</url>
 
 	<properties>
-		<fhir.version>4.2.3</fhir.version>
+		<fhir.version>4.7.0</fhir.version>
 		<lombok.version>1.18.12</lombok.version>
 		<jackson.version>2.10.2</jackson.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
This is to allow dependencies to resolve on **chw-core** `master-v1` which is in use by **Boresha Afya** and **HF** client apps. 