### PR TITLE
Add null check for owner

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<artifactId>opensrp-plan-evaluator</artifactId>
 	<packaging>jar</packaging>
-	<version>1.6.1-SNAPSHOT</version>
+	<version>1.6.2-SNAPSHOT</version>
 	<name>OpenSRP  Plan Evaluator</name>
 	<description>OpenSRP  Plan Evaluator Library</description>
 	<url>https://github.com/OpenSRP/opensrp-plan-evaluator</url>

--- a/src/main/java/org/smartregister/converters/TaskConverter.java
+++ b/src/main/java/org/smartregister/converters/TaskConverter.java
@@ -74,9 +74,12 @@ public class TaskConverter {
 		if (StringUtils.isNotBlank(domainTask.getRequester())) {
 			builder.requester(Reference.builder().reference(String.of(domainTask.getRequester())).build());
 		}
-		
-		Reference owner = Reference.builder().reference(String.builder().value(domainTask.getOwner()).build()).build();
-		
+
+		Reference owner = null;
+		if (StringUtils.isNotBlank(domainTask.getOwner())) {
+			owner = Reference.builder().reference(String.builder().value(domainTask.getOwner()).build()).build();
+		}
+
 		if (StringUtils.isNotBlank(domainTask.getReasonReference())) {
 			builder.statusReason(CodeableConcept.builder().text(String.of(domainTask.getReasonReference())).build());
 		}


### PR DESCRIPTION
Conversion of tasks to fhir resources is failing when the `owner` field is null / empty.
We need to add a null check to prevent client apps from crashing