### PR TITLE
Location convertion bug fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<artifactId>opensrp-plan-evaluator</artifactId>
 	<packaging>jar</packaging>
-	<version>1.6.2-SNAPSHOT</version>
+	<version>1.6.3-SNAPSHOT</version>
 	<name>OpenSRP  Plan Evaluator</name>
 	<description>OpenSRP  Plan Evaluator Library</description>
 	<url>https://github.com/OpenSRP/opensrp-plan-evaluator</url>

--- a/src/main/java/org/smartregister/converters/LocationConverter.java
+++ b/src/main/java/org/smartregister/converters/LocationConverter.java
@@ -61,7 +61,7 @@ public class LocationConverter {
 			builder.meta(meta);
 		}
 		
-		if (physicalLocation.getProperties().getCustomProperties().get("name_en") != null) {
+		if (StringUtils.isNotBlank(physicalLocation.getProperties().getCustomProperties().get("name_en"))) {
 			builder.alias(String.of(physicalLocation.getProperties().getCustomProperties().get("name_en")));
 		}
 		
@@ -70,6 +70,9 @@ public class LocationConverter {
 		
 		for (Map.Entry<java.lang.String, java.lang.String> entry : physicalLocation.getProperties().getCustomProperties()
 		        .entrySet()) {
+			if (StringUtils.isBlank(entry.getValue())) {
+				continue;
+			}
 			identifier = Identifier.builder().system(Uri.builder().value(entry.getKey()).build())
 			        .value(String.builder().value(entry.getValue()).build()).build();
 			identifiers.add(identifier);

--- a/src/test/java/org/smartregister/converters/LocationConverterTest.java
+++ b/src/test/java/org/smartregister/converters/LocationConverterTest.java
@@ -139,4 +139,27 @@ public class LocationConverterTest {
 		assertEquals("false", location.getIdentifier().get(0).getValue().getValue());
 		System.out.println(location);
 	}
+
+	@Test
+	public void testConvertToFihrLocationWithEmptyNameEnValue() {
+		PhysicalLocation physicalLocation;
+		physicalLocation = gson.fromJson(parentJson, PhysicalLocation.class);
+		physicalLocation.getProperties().getCustomProperties().put("name_en","");
+		Location location = LocationConverter.convertPhysicalLocationToLocationResource(physicalLocation);
+		assertNotNull(location);
+		assertEquals(StringUtils.toRootLowerCase(physicalLocation.getProperties().getStatus().name()),
+				location.getStatus().getValueAsEnumConstant().value());
+		assertEquals(physicalLocation.getProperties().getParentId(), location.getPartOf().getReference().getValue());
+		assertEquals(physicalLocation.getProperties().getName(), location.getName().getValue());
+		assertEquals(String.valueOf(physicalLocation.getProperties().getVersion()),
+				location.getMeta().getVersionId().getValue());
+		Long locationServerVersion = location.getMeta().getLastUpdated().getValue().toInstant().toEpochMilli();
+		assertEquals(physicalLocation.getServerVersion(), locationServerVersion);
+		assertEquals("instance", location.getMode().getValue());
+		assertEquals("bu", location.getPhysicalType().getCoding().get(0).getCode().getValue());
+		assertEquals(physicalLocation.getProperties().getCustomProperties().size() + 1, location.getIdentifier().size());
+		assertEquals("hasGeometry", location.getIdentifier().get(0).getSystem().getValue());
+		assertEquals("true", location.getIdentifier().get(0).getValue().getValue());
+		System.out.println(location);
+	}
 }

--- a/src/test/java/org/smartregister/converters/LocationConverterTest.java
+++ b/src/test/java/org/smartregister/converters/LocationConverterTest.java
@@ -157,7 +157,7 @@ public class LocationConverterTest {
 		assertEquals(physicalLocation.getServerVersion(), locationServerVersion);
 		assertEquals("instance", location.getMode().getValue());
 		assertEquals("bu", location.getPhysicalType().getCoding().get(0).getCode().getValue());
-		assertEquals(physicalLocation.getProperties().getCustomProperties().size() + 1, location.getIdentifier().size());
+		assertEquals(physicalLocation.getProperties().getCustomProperties().size(), location.getIdentifier().size());
 		assertEquals("hasGeometry", location.getIdentifier().get(0).getSystem().getValue());
 		assertEquals("true", location.getIdentifier().get(0).getValue().getValue());
 		System.out.println(location);


### PR DESCRIPTION
Convertion of opensrp location to fhir location resource is failing when the `name_en` property value is an empty string.
Add a check for empty strings.