### PR TITLE
use gsonbuilder for tostring methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<artifactId>opensrp-plan-evaluator</artifactId>
 	<packaging>jar</packaging>
-	<version>1.6.5-SNAPSHOT</version>
+	<version>1.6.6-SNAPSHOT</version>
 	<name>OpenSRP  Plan Evaluator</name>
 	<description>OpenSRP  Plan Evaluator Library</description>
 	<url>https://github.com/OpenSRP/opensrp-plan-evaluator</url>
@@ -120,7 +120,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
-			<version>3.10</version>
+			<version>3.12.0</version>
 		</dependency>
 		<dependency>
             <groupId>org.jacoco</groupId>

--- a/src/main/java/org/smartregister/domain/Address.java
+++ b/src/main/java/org/smartregister/domain/Address.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import com.google.gson.GsonBuilder;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -464,6 +465,6 @@ public class Address implements Serializable {
 	
 	@Override
 	public String toString() {
-		return ToStringBuilder.reflectionToString(this);
+		return new GsonBuilder().setPrettyPrinting().create().toJson(this);
 	}
 }

--- a/src/main/java/org/smartregister/domain/Client.java
+++ b/src/main/java/org/smartregister/domain/Client.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import com.google.gson.GsonBuilder;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -358,7 +359,7 @@ public class Client extends BaseEntity {
 	
 	@Override
 	public String toString() {
-		return ToStringBuilder.reflectionToString(this);
+		return new GsonBuilder().setPrettyPrinting().create().toJson(this);
 	}
 	
 }

--- a/src/main/java/org/smartregister/domain/Event.java
+++ b/src/main/java/org/smartregister/domain/Event.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import com.google.gson.GsonBuilder;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -454,7 +455,7 @@ public class Event extends BaseDataObject {
 	
 	@Override
 	public String toString() {
-		return ToStringBuilder.reflectionToString(this);
+		return new GsonBuilder().setPrettyPrinting().create().toJson(this);
 	}
 	
 }

--- a/src/main/java/org/smartregister/domain/Obs.java
+++ b/src/main/java/org/smartregister/domain/Obs.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.google.gson.GsonBuilder;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -322,7 +323,7 @@ public class Obs implements Serializable {
 	
 	@Override
 	public String toString() {
-		return ToStringBuilder.reflectionToString(this);
+		return new GsonBuilder().setPrettyPrinting().create().toJson(this);
 	}
 
 

--- a/src/main/java/org/smartregister/domain/Stock.java
+++ b/src/main/java/org/smartregister/domain/Stock.java
@@ -1,5 +1,6 @@
 package org.smartregister.domain;
 
+import com.google.gson.GsonBuilder;
 import com.google.gson.annotations.SerializedName;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -242,7 +243,7 @@ public class Stock extends BaseDataObject {
 	
 	@Override
 	public String toString() {
-		return ToStringBuilder.reflectionToString(this);
+		return new GsonBuilder().setPrettyPrinting().create().toJson(this);
 	}
 	
 }

--- a/src/main/java/org/smartregister/domain/User.java
+++ b/src/main/java/org/smartregister/domain/User.java
@@ -3,6 +3,7 @@ package org.smartregister.domain;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.google.gson.GsonBuilder;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -252,7 +253,7 @@ public class User extends BaseEntity {
 	
 	@Override
 	public String toString() {
-		return ToStringBuilder.reflectionToString(this);
+		return new GsonBuilder().setPrettyPrinting().create().toJson(this);
 	}
 	
 }

--- a/src/test/java/org/smartregister/converters/ClientConverterTest.java
+++ b/src/test/java/org/smartregister/converters/ClientConverterTest.java
@@ -7,6 +7,7 @@ import com.ibm.fhir.model.type.CodeableConcept;
 import com.ibm.fhir.model.type.Identifier;
 import com.ibm.fhir.path.FHIRPathElementNode;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.junit.Test;
 import org.smartregister.domain.Client;
 import org.smartregister.pathevaluator.PathEvaluatorLibrary;
@@ -27,8 +28,10 @@ public class ClientConverterTest {
 	@Test
 	public void testConvertToPatientResource() {
 		Client client = gson.fromJson(CLIENT_JSON, Client.class);
-		client.setBirthdate(new DateTime(0l));
-		client.setDeathdate(new DateTime(0l));
+		DateTimeZone zoneUTC = DateTimeZone.UTC;
+		DateTime epochDateTime = new DateTime(0l, zoneUTC);
+		client.setBirthdate(epochDateTime);
+		client.setDeathdate(epochDateTime);
 		client.setFirstName("John");
 		client.setMiddleName("Lewis");
 		client.setLastName("Johny");
@@ -67,8 +70,10 @@ public class ClientConverterTest {
 	@Test
 	public void testConvertToPatientResourceV2() {
 		Client client = gson.fromJson(CLIENT_JSON_2, Client.class);
-		client.setBirthdate(new DateTime(0l));
-		client.setDeathdate(new DateTime(0l));
+		DateTimeZone zoneUTC = DateTimeZone.UTC;
+		DateTime epochDateTime = new DateTime(0l, zoneUTC);
+		client.setBirthdate(epochDateTime);
+		client.setDeathdate(epochDateTime);
 		client.setFirstName("John");
 		client.setMiddleName("Lewis");
 		client.setLastName("Johny");

--- a/src/test/java/org/smartregister/converters/TaskConverterTest.java
+++ b/src/test/java/org/smartregister/converters/TaskConverterTest.java
@@ -16,20 +16,19 @@ import static org.junit.Assert.assertNotNull;
 
 public class TaskConverterTest {
 	
-	private String taskJson = "{\"identifier\":\"tsk11231jh22\",\"planIdentifier\":\"IRS_2018_S1\",\"groupIdentifier\":\"2018_IRS-3734{\",\"status\":\"Ready\",\"businessStatus\":\"Not Visited\",\"priority\":\"routine\",\"code\":\"IRS\",\"description\":\"Spray House\",\"focus\":\"IRS Visit\",\"for\":\"location.properties.uid:41587456-b7c8-4c4e-b433-23a786f742fc\",\"executionPeriod\": {\"start\":\"2018-11-10T22:00\",\"end\":\"2019-11-10T21:00\"},\"authoredOn\":\"2018-10-31T07:00\",\"lastModified\":\"2018-10-31T07:00\",\"owner\":\"demouser\",\"note\":[{\"authorString\":\"demouser\",\"time\":\"2018-01-01T08:00\",\"text\":\"This should be assigned to patrick.\"}],\"serverVersion\":0,\"reasonReference\":\"reasonrefuuid\",\"location\":\"catchment1\",\"requester\":\"chw1\"}";
-	
+	private String taskJson = "{\"identifier\":\"tsk11231jh22\",\"planIdentifier\":\"IRS_2018_S1\",\"groupIdentifier\":\"2018_IRS-3734{\",\"status\":\"Ready\",\"businessStatus\":\"Not Visited\",\"priority\":\"routine\",\"code\":\"IRS\",\"description\":\"Spray House\",\"focus\":\"IRS Visit\",\"for\":\"location.properties.uid:41587456-b7c8-4c4e-b433-23a786f742fc\",\"executionPeriod\": {\"start\":\"2018-11-10T2200\",\"end\":\"2019-11-10T2100\"},\"authoredOn\":\"2018-10-31T0700\",\"lastModified\":\"2018-10-31T0700\",\"owner\":\"demouser\",\"note\":[{\"authorString\":\"demouser\",\"time\":\"2018-01-01T0800\",\"text\":\"This should be assigned to patrick.\"}],\"serverVersion\":0,\"reasonReference\":\"reasonrefuuid\",\"location\":\"catchment1\",\"requester\":\"chw1\"}";
 	private String dateFormat = "yyyy-MM-dd'T'HH:mm'Z'";
 	
-	private static Gson gson = new GsonBuilder().registerTypeAdapter(DateTime.class, new TaskDateTimeTypeConverter("yyyy-MM-dd'T'HH:mm'Z'"))
+	private static Gson gson = new GsonBuilder().registerTypeAdapter(DateTime.class, new TaskDateTimeTypeConverter())
 	        .serializeNulls().create();
 	
 	@Test
 	public void testConvertToFhirTask() {
 		org.smartregister.domain.Task task = gson.fromJson(taskJson, org.smartregister.domain.Task.class);
-//		DateTime testNotetime = task.getNotes().get(0).getTime();
-//		DateTimeZone zoneUTC = DateTimeZone.UTC;
-//		DateTime utcTime = testNotetime.withZone(zoneUTC);
-//		task.getNotes().get(0).setTime(utcTime);
+		DateTime testNotetime = task.getNotes().get(0).getTime();
+		DateTimeZone zoneUTC = DateTimeZone.UTC;
+		DateTime utcTime = testNotetime.withZone(zoneUTC);
+		task.getNotes().get(0).setTime(utcTime);
 		Task fihrTask = TaskConverter.convertTasktoFihrResource(task);
 		assertNotNull(fihrTask);
 		assertEquals(fihrTask.getStatus().getValueAsEnumConstant().value(),

--- a/src/test/java/org/smartregister/converters/TaskConverterTest.java
+++ b/src/test/java/org/smartregister/converters/TaskConverterTest.java
@@ -5,6 +5,7 @@ import com.google.gson.GsonBuilder;
 import com.ibm.fhir.model.resource.Task;
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.junit.Test;
 import org.smartregister.domain.Period;
 import org.smartregister.domain.Task.Restriction;
@@ -15,16 +16,20 @@ import static org.junit.Assert.assertNotNull;
 
 public class TaskConverterTest {
 	
-	private String taskJson = "{\"identifier\":\"tsk11231jh22\",\"planIdentifier\":\"IRS_2018_S1\",\"groupIdentifier\":\"2018_IRS-3734{\",\"status\":\"Ready\",\"businessStatus\":\"Not Visited\",\"priority\":\"routine\",\"code\":\"IRS\",\"description\":\"Spray House\",\"focus\":\"IRS Visit\",\"for\":\"location.properties.uid:41587456-b7c8-4c4e-b433-23a786f742fc\",\"executionPeriod\": {\"start\":\"2018-11-10T2200\",\"end\":\"2019-11-10T2100\"},\"authoredOn\":\"2018-10-31T0700\",\"lastModified\":\"2018-10-31T0700\",\"owner\":\"demouser\",\"note\":[{\"authorString\":\"demouser\",\"time\":\"2018-01-01T0800\",\"text\":\"This should be assigned to patrick.\"}],\"serverVersion\":0,\"reasonReference\":\"reasonrefuuid\",\"location\":\"catchment1\",\"requester\":\"chw1\"}";
+	private String taskJson = "{\"identifier\":\"tsk11231jh22\",\"planIdentifier\":\"IRS_2018_S1\",\"groupIdentifier\":\"2018_IRS-3734{\",\"status\":\"Ready\",\"businessStatus\":\"Not Visited\",\"priority\":\"routine\",\"code\":\"IRS\",\"description\":\"Spray House\",\"focus\":\"IRS Visit\",\"for\":\"location.properties.uid:41587456-b7c8-4c4e-b433-23a786f742fc\",\"executionPeriod\": {\"start\":\"2018-11-10T22:00\",\"end\":\"2019-11-10T21:00\"},\"authoredOn\":\"2018-10-31T07:00\",\"lastModified\":\"2018-10-31T07:00\",\"owner\":\"demouser\",\"note\":[{\"authorString\":\"demouser\",\"time\":\"2018-01-01T08:00\",\"text\":\"This should be assigned to patrick.\"}],\"serverVersion\":0,\"reasonReference\":\"reasonrefuuid\",\"location\":\"catchment1\",\"requester\":\"chw1\"}";
 	
 	private String dateFormat = "yyyy-MM-dd'T'HH:mm'Z'";
 	
-	private static Gson gson = new GsonBuilder().registerTypeAdapter(DateTime.class, new TaskDateTimeTypeConverter())
+	private static Gson gson = new GsonBuilder().registerTypeAdapter(DateTime.class, new TaskDateTimeTypeConverter("yyyy-MM-dd'T'HH:mm'Z'"))
 	        .serializeNulls().create();
 	
 	@Test
 	public void testConvertToFhirTask() {
 		org.smartregister.domain.Task task = gson.fromJson(taskJson, org.smartregister.domain.Task.class);
+//		DateTime testNotetime = task.getNotes().get(0).getTime();
+//		DateTimeZone zoneUTC = DateTimeZone.UTC;
+//		DateTime utcTime = testNotetime.withZone(zoneUTC);
+//		task.getNotes().get(0).setTime(utcTime);
 		Task fihrTask = TaskConverter.convertTasktoFihrResource(task);
 		assertNotNull(fihrTask);
 		assertEquals(fihrTask.getStatus().getValueAsEnumConstant().value(),


### PR DESCRIPTION
Fixed: The toString() method throwing exceptions in devices running Android 5.1.1.
- Used `Gson` instead of `apache.commons.lang3` for the above function in classes found in the [domain](https://github.com/opensrp/opensrp-plan-evaluator/tree/master/src/main/java/org/smartregister/domain) package
